### PR TITLE
Автоматическая высота диалогового окна

### DIFF
--- a/assets/components/autoredirector/js/mgr/widgets/items.grid.js
+++ b/assets/components/autoredirector/js/mgr/widgets/items.grid.js
@@ -162,7 +162,7 @@ autoRedirector.window.CreateItem = function(config) {
 	Ext.applyIf(config,{
 		title: _('autoredirector_item_create')
 		,id: this.ident
-		,height: 200
+		,height: 'auto'
 		,width: 475
 		,url: autoRedirector.config.connector_url
 		,action: 'mgr/item/create'
@@ -190,7 +190,7 @@ autoRedirector.window.UpdateItem = function(config) {
 	Ext.applyIf(config,{
 		title: _('autoredirector_item_update')
 		,id: this.ident
-		,height: 200
+		,height: 'auto'
 		,width: 475
 		,url: autoRedirector.config.connector_url
 		,action: 'mgr/item/update'


### PR DESCRIPTION
Спасибо за шикарный компонент. Единственное неудобство при работе с ним, это неполное открытие модального окна при добавлении или редактировании правил. Окно открывается на первых два поля, а поле Контекст остается скрытым и к нему приходится прокручивать, что неудобно. Данное исправление убирает этот небольшой недостаток :)

![autoredirector-update](https://cloud.githubusercontent.com/assets/15892462/21081970/3c1aa20c-bfda-11e6-9ec2-449bca07738a.gif)
